### PR TITLE
Feat/assignee suggestion

### DIFF
--- a/src/main/java/com/ssssogong/issuemanager/config/Initializer.java
+++ b/src/main/java/com/ssssogong/issuemanager/config/Initializer.java
@@ -1,14 +1,20 @@
 package com.ssssogong.issuemanager.config;
 
+import com.ssssogong.issuemanager.domain.Issue;
 import com.ssssogong.issuemanager.domain.Project;
 import com.ssssogong.issuemanager.domain.UserProject;
 import com.ssssogong.issuemanager.domain.account.User;
+import com.ssssogong.issuemanager.domain.enumeration.Category;
+import com.ssssogong.issuemanager.domain.enumeration.Priority;
+import com.ssssogong.issuemanager.domain.enumeration.State;
 import com.ssssogong.issuemanager.domain.role.Role;
 import com.ssssogong.issuemanager.exception.RoleSettingException;
+import com.ssssogong.issuemanager.repository.IssueRepository;
 import com.ssssogong.issuemanager.repository.ProjectRepository;
 import com.ssssogong.issuemanager.repository.RoleRepository;
 import com.ssssogong.issuemanager.repository.UserProjectRepository;
 import com.ssssogong.issuemanager.repository.UserRepository;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.reflections.Reflections;
@@ -54,6 +60,7 @@ public class Initializer implements ApplicationRunner {
     private final ProjectRepository projectRepository;
     private final UserProjectRepository userProjectRepository;
     private final PasswordEncoder passwordEncoder;
+    private final IssueRepository issueRepository;
 
 
     private boolean roleDoesNotExist(final List<Role> roles, final String expectedRoleName) {
@@ -246,6 +253,22 @@ public class Initializer implements ApplicationRunner {
                     userProjectRepository.save(userProjects.get(idx++));
             }
             System.out.println("Initializer: saved userProjects");
+
+            //이슈 저장! 통계 내려면 이슈는 다다익선이니까~ 실행될때마다 tester, category, priority 랜덤 저장됨
+            Random random = new Random();
+            final Category[] categories = Category.values();
+            final Priority[] priorities = Priority.values();
+            issueRepository.save(Issue.builder()
+                    .project(project)
+                    .title("prepared issue")
+                    .description("this is description!")
+                    .category(categories[random.nextInt(categories.length)])
+                    .priority(priorities[random.nextInt(priorities.length)])
+                    .state(State.NEW)
+                    .reporter(tester.get(random.nextInt(tester.size())))
+                    .build()
+            );
+
         } catch (Exception e) {
 //            System.out.println("Initializer Exception: " + e.getMessage());
             log.error("Initializer Exception", e);

--- a/src/main/java/com/ssssogong/issuemanager/controller/IssueController.java
+++ b/src/main/java/com/ssssogong/issuemanager/controller/IssueController.java
@@ -5,7 +5,6 @@ import com.ssssogong.issuemanager.service.IssueImageService;
 import com.ssssogong.issuemanager.service.IssueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -75,5 +74,16 @@ public class IssueController {
 
         List<IssueProjectResponseDto> issues = issueService.findIssuesInProject(projectId, title, priority, state, category, reporter, fixer, assignee, issueCount);
         return ResponseEntity.ok(issues);
+    }
+
+    // 이슈에 대한 assignee 추천
+    //todo: 응답 포맷
+    @GetMapping("/projects/{projectId}/issues/{issueId}/assignee-suggestion")
+    public ResponseEntity<List<UserResponseDto>> suggestAssignee(
+            @PathVariable("projectId") Long projectId,
+            @PathVariable("issueId") Long issueId
+    ) {
+        List<UserResponseDto> response = issueService.suggestAssignee(projectId, issueId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ssssogong/issuemanager/controller/IssueController.java
+++ b/src/main/java/com/ssssogong/issuemanager/controller/IssueController.java
@@ -77,7 +77,6 @@ public class IssueController {
     }
 
     // 이슈에 대한 assignee 추천
-    //todo: 응답 포맷
     @GetMapping("/projects/{projectId}/issues/{issueId}/assignee-suggestion")
     public ResponseEntity<List<UserResponseDto>> suggestAssignee(
             @PathVariable("projectId") Long projectId,

--- a/src/main/java/com/ssssogong/issuemanager/domain/AssigneeSuggestionPolicy.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/AssigneeSuggestionPolicy.java
@@ -8,5 +8,5 @@ public interface AssigneeSuggestionPolicy {
     /**
      * Assignee 추천 정책이 다양하게(ex. 랜덤, 가중치.. 등등) 있을 수 있음을 고려하여 인터페이스로 만들었습니다.
      */
-    List<User> suggest(Issue issue);
+    List<User> suggest(final Issue issue, final List<User> developers);
 }

--- a/src/main/java/com/ssssogong/issuemanager/domain/AssigneeSuggestionPolicy.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/AssigneeSuggestionPolicy.java
@@ -1,0 +1,12 @@
+package com.ssssogong.issuemanager.domain;
+
+import com.ssssogong.issuemanager.domain.account.User;
+import java.util.List;
+
+public interface AssigneeSuggestionPolicy {
+
+    /**
+     * Assignee 추천 정책이 다양하게(ex. 랜덤, 가중치.. 등등) 있을 수 있음을 고려하여 인터페이스로 만들었습니다.
+     */
+    List<User> suggest(Issue issue);
+}

--- a/src/main/java/com/ssssogong/issuemanager/domain/Issue.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/Issue.java
@@ -85,4 +85,8 @@ public class Issue extends BaseEntity {
             this.state = State.valueOf(state);
 
     }
+
+    public boolean hasResolvedHistory() {
+        return issueModifications.stream().anyMatch(each -> each.getTo() == State.RESOLVED);
+    }
 }

--- a/src/main/java/com/ssssogong/issuemanager/domain/WeightCalculator.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/WeightCalculator.java
@@ -1,0 +1,6 @@
+package com.ssssogong.issuemanager.domain;
+
+@FunctionalInterface
+interface WeightCalculator {
+    int calculateWeight(Issue currentIssue, Issue pastIssue);
+}

--- a/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
@@ -1,0 +1,21 @@
+package com.ssssogong.issuemanager.domain;
+
+import com.ssssogong.issuemanager.domain.account.User;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WeightedAssigneeSuggestionPolicy implements AssigneeSuggestionPolicy {
+
+    /**
+     * 이슈에 할당할 Assignee 3명을 추천하는 기능
+     * - 유저 별로 가중치를 둬서 가중치가 가장 높은 사람 추천
+     *  1. category별로 해결(resolve까지 완료)한 사람
+     *  2. 중요도 높은 거 해결한 사람(BLOCKER, CRITICAL, MAJOR, MINOR, TRIVIAL)
+     */
+
+    @Override
+    public List<User> suggest(final Issue issue) {
+        return null;
+    }
+}

--- a/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
@@ -1,7 +1,12 @@
 package com.ssssogong.issuemanager.domain;
 
 import com.ssssogong.issuemanager.domain.account.User;
+import com.ssssogong.issuemanager.domain.enumeration.Category;
+import com.ssssogong.issuemanager.domain.enumeration.Priority;
+import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,8 +19,57 @@ public class WeightedAssigneeSuggestionPolicy implements AssigneeSuggestionPolic
      *  2. 중요도 높은 거 해결한 사람(BLOCKER, CRITICAL, MAJOR, MINOR, TRIVIAL)
      */
 
+    private static final int MAX_SUGGESTION_COUNT = 3;
+    private static final int SAME_CATEGORY_WEIGHT = 5; //같은 카테고리의 이슈를 해결했다면 가중치 준다.
+    private static final Map<Priority, Integer> priorityWeights = new EnumMap<>(Priority.class);
+
+    static {
+        // 해결한 이슈의 중요도에 따른 가중치를 준다.
+        priorityWeights.put(Priority.BLOCKER, 5);
+        priorityWeights.put(Priority.CRITICAL, 4);
+        priorityWeights.put(Priority.MAJOR, 3);
+        priorityWeights.put(Priority.MINOR, 2);
+        priorityWeights.put(Priority.TRIVIAL, 1);
+    }
+
     @Override
-    public List<User> suggest(final Issue issue) {
-        return null;
+    public List<User> suggest(final Issue issue, final List<User> developers) {
+        final Project project = issue.getProject();
+        final List<Issue> issues = project.getIssues();
+        final Category category = issue.getCategory();
+        System.out.println("category = " + category);
+
+        // 유저별 가중치 초기화
+        Map<User, Integer> userWeights = new HashMap<>();
+        for (User developer : developers) {
+            userWeights.put(developer, 0);
+        }
+
+        for (Issue each : issues) {
+            if(each.hasResolvedHistory()) {
+                final User fixer = each.getFixer();
+                //중요도 가중치
+                final Priority priority = each.getPriority();
+                userWeights.computeIfPresent(fixer, (key, weight) -> weight + priorityWeights.get(priority));
+                //카테고리 가중치
+                System.out.println("each.getCategory() = " + each.getCategory());
+                if(category == each.getCategory()) {
+                    System.out.println("들어왔다!: " + fixer.getAccountId());
+                    userWeights.computeIfPresent(fixer, (key, weight) -> weight + SAME_CATEGORY_WEIGHT);
+                }
+            }
+        }
+
+        for (User user : userWeights.keySet()) {
+            System.out.println("user = " + user.getAccountId());
+            System.out.println("userWeights.get(user) = " + userWeights.get(user));
+        }
+
+        // 최대 MAX_SUGGESTION_COUNT 만큼의 유저 리스트를 반환
+        return userWeights.entrySet().stream()
+                .sorted(Map.Entry.<User, Integer>comparingByValue().reversed())
+                .limit(MAX_SUGGESTION_COUNT)
+                .map(Map.Entry::getKey)
+                .toList();
     }
 }

--- a/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
@@ -37,12 +37,7 @@ public class WeightedAssigneeSuggestionPolicy implements AssigneeSuggestionPolic
         final Project project = issue.getProject();
         final List<Issue> issues = project.getIssues();
         final Category category = issue.getCategory();
-
-        // 유저별 가중치 초기화
-        Map<User, Integer> userWeights = new HashMap<>();
-        for (User developer : developers) {
-            userWeights.put(developer, 0);
-        }
+        Map<User, Integer> userWeights = initializeWeights(developers);
 
         for (Issue each : issues) {
             if(each.hasResolvedHistory()) {
@@ -57,7 +52,18 @@ public class WeightedAssigneeSuggestionPolicy implements AssigneeSuggestionPolic
             }
         }
 
-        // 최대 MAX_SUGGESTION_COUNT 만큼의 유저 리스트를 반환
+        return findTopWeightedUsers(userWeights);
+    }
+
+    private Map<User, Integer> initializeWeights(final List<User> developers) {
+        Map<User, Integer> userWeights = new HashMap<>();
+        for (User developer : developers) {
+            userWeights.put(developer, 0);
+        }
+        return userWeights;
+    }
+
+    private List<User> findTopWeightedUsers(final Map<User, Integer> userWeights) {
         return userWeights.entrySet().stream()
                 .sorted(Map.Entry.<User, Integer>comparingByValue().reversed())
                 .limit(MAX_SUGGESTION_COUNT)

--- a/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
+++ b/src/main/java/com/ssssogong/issuemanager/domain/WeightedAssigneeSuggestionPolicy.java
@@ -37,7 +37,6 @@ public class WeightedAssigneeSuggestionPolicy implements AssigneeSuggestionPolic
         final Project project = issue.getProject();
         final List<Issue> issues = project.getIssues();
         final Category category = issue.getCategory();
-        System.out.println("category = " + category);
 
         // 유저별 가중치 초기화
         Map<User, Integer> userWeights = new HashMap<>();
@@ -52,17 +51,10 @@ public class WeightedAssigneeSuggestionPolicy implements AssigneeSuggestionPolic
                 final Priority priority = each.getPriority();
                 userWeights.computeIfPresent(fixer, (key, weight) -> weight + priorityWeights.get(priority));
                 //카테고리 가중치
-                System.out.println("each.getCategory() = " + each.getCategory());
                 if(category == each.getCategory()) {
-                    System.out.println("들어왔다!: " + fixer.getAccountId());
                     userWeights.computeIfPresent(fixer, (key, weight) -> weight + SAME_CATEGORY_WEIGHT);
                 }
             }
-        }
-
-        for (User user : userWeights.keySet()) {
-            System.out.println("user = " + user.getAccountId());
-            System.out.println("userWeights.get(user) = " + userWeights.get(user));
         }
 
         // 최대 MAX_SUGGESTION_COUNT 만큼의 유저 리스트를 반환

--- a/src/main/java/com/ssssogong/issuemanager/mapper/UserMapper.java
+++ b/src/main/java/com/ssssogong/issuemanager/mapper/UserMapper.java
@@ -7,6 +7,7 @@ import com.ssssogong.issuemanager.dto.RegisterRequestDto;
 import com.ssssogong.issuemanager.dto.UserDto;
 import com.ssssogong.issuemanager.dto.UserResponseDto;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -73,6 +74,12 @@ public class UserMapper {
                 .username(user.getUsername())
                 .accountId(user.getAccountId())
                 .build();
+    }
+
+    public static List<UserResponseDto> toUserResponseDTO(List<User> users){
+        return users.stream()
+                .map(UserMapper::toUserResponseDTO)
+                .toList();
     }
 
     public static UserResponseDto toUserResponseDTO(UserDto userDto){


### PR DESCRIPTION
나름 Assignee 정하는 정책이 바뀔 수 있기 때문에 AssigneeSuggestionPolicy 인터페이스를 만들었습니다.
- WeightedAssigneeSuggestionPolicy 클래스에서 가중치에 따른 assignee를 추천해줍니다.
- WeightCalculator 이거는 함수형 인터페이스인데 WeightedAssigneeSuggestionPolicy 클래스 내부에서 중요도에 따른 가중치 규칙, 카테고리에 따른 가중치 규칙을 모아놓는데 사용됩니당

현재 가중치 규칙은 아래와 같습니다
- 카테고리 같으면 +5
- 중요도 높은거 -> 낮은거 갈수록 5 -> 1

가중치 합산해서 상위 3명 반환합니다.
(프로젝트에 참여중인 developer가 3명보다 작다면 3명보다 작게 반환됩니다.)

Initializer에 어플리케이션 한번 실행할때마다 NEW 상태의 이슈 하나(테스터 랜덤, 중요도 랜덤, 카테고리 랜덤) 해서 추가하는 코드 추가했슴다(통계기능 하려면 이슈 좀 있어야 되니까...?) 더 좋은 아이디어 있음 제안 ㄱㄱ